### PR TITLE
Final Hotfixes for Elastic Beanstalk

### DIFF
--- a/micro-location/micro-location/AppDelegate.m
+++ b/micro-location/micro-location/AppDelegate.m
@@ -30,8 +30,8 @@
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
-    //self.beaconUUID = [[NSUUID alloc] initWithUUIDString:@"F4913F46-75F4-9134-913F-4913F4913F49"]; //gimbal uuid
-    self.beaconUUID = [[NSUUID alloc] initWithUUIDString:@"B9407F30-F5F8-466E-AFF9-25556B57FE6D"];  //estimote uuid
+    self.beaconUUID = [[NSUUID alloc] initWithUUIDString:@"F4913F46-75F4-9134-913F-4913F4913F49"]; //gimbal uuid
+    //self.beaconUUID = [[NSUUID alloc] initWithUUIDString:@"B9407F30-F5F8-466E-AFF9-25556B57FE6D"];  //estimote uuid
     [DDLog addLogger:[DDASLLogger sharedInstance]];
     [DDLog addLogger:[DDTTYLogger sharedInstance]];
     
@@ -116,11 +116,18 @@
     
     for (CLBeacon *beacon in [Singleton instance].beacons)
     {
-        NSString *uuid = [NSString stringWithFormat:@"%@",beacon.proximityUUID];
+        //beacon.proximityUUID = "<_NSConcreteUUIDx .... > " followed by the actual UUID
+        //The array separates that string into two parts: everything up to the "> " is object 0 of the arry
+        //everything afterwards, i.e. the UUID is part 1
+        NSString *noFormatUUID = [NSString stringWithFormat:@"%@",beacon.proximityUUID];
+        NSArray *uuidFormatArray = [noFormatUUID componentsSeparatedByString:@"> "];
+        NSString *formatUUID = uuidFormatArray[1];
+    
+        
         NSString *major = [beacon.major stringValue];
         NSString *minor = [beacon.minor stringValue];
         
-        NSDictionary *params = @ {@"uuid" :uuid, @"major" :major, @"minor" :minor };
+        NSDictionary *params = @ {@"uuid" :formatUUID, @"major" :major, @"minor" :minor };
         GetBeaconService *beaconService = [GetBeaconService sharedClient];
         beaconService.mGetBeaconServiceDelegate = self;
         

--- a/micro-location/micro-location/GetBeaconService.m
+++ b/micro-location/micro-location/GetBeaconService.m
@@ -29,7 +29,7 @@
     static GetBeaconService* _sharedClient = nil;
     static dispatch_once_t oncePredicate;
     dispatch_once(&oncePredicate, ^{
-        _sharedClient = [[self alloc] initWithBaseURL:[NSURL URLWithString:@"http://default-environment-tvmbb2aymn.elasticbeanstalk.com"]];
+        _sharedClient = [[self alloc] initWithBaseURL:[NSURL URLWithString:@"http://microlocation.elasticbeanstalk.com"]];
     });
     
     return _sharedClient;

--- a/micro-location/micro-location/SecondViewController.m
+++ b/micro-location/micro-location/SecondViewController.m
@@ -158,7 +158,7 @@
             NSString *onOffString = @"";
             NSDictionary *params = @ {};
             
-            if ([beacon.name isEqualToString:@"TV"] && ![Singleton instance].hasCalledWemoScript && thisCLBeacon.proximity == CLProximityImmediate)
+            if ([beacon.name isEqualToString:@"tv"] && ![Singleton instance].hasCalledWemoScript && thisCLBeacon.proximity == CLProximityImmediate)
             {
                 onOffString = @"on";
                 params = @ {@"onoroff" : onOffString};
@@ -166,7 +166,7 @@
                 NSError *error = [wemoService runWemoScriptwithParams:params];
                 [Singleton instance].hasCalledWemoScript = true;
             }
-            else if ([beacon.name isEqualToString:@"TV"] && [Singleton instance].hasCalledWemoScript && thisCLBeacon.proximity != CLProximityImmediate && thisCLBeacon.proximity != CLProximityNear)
+            else if ([beacon.name isEqualToString:@"tv"] && [Singleton instance].hasCalledWemoScript && thisCLBeacon.proximity != CLProximityImmediate && thisCLBeacon.proximity != CLProximityNear)
             {
                 onOffString = @"off";
                 params = @ {@"onoroff" : onOffString};

--- a/micro-location/micro-location/WemoScriptService.h
+++ b/micro-location/micro-location/WemoScriptService.h
@@ -17,7 +17,7 @@
 
 @interface WemoScriptService : AFHTTPClient
 +(WemoScriptService*) sharedClient;
-- (NSError *)runWemoScriptwithParams:(NSDictionary *)params
+- (NSError *)runWemoScriptwithParams:(NSDictionary *)params;
 
 @property (nonatomic, weak) id <WemoScriptServiceDelegate> mWemoScriptServiceDelegate;
 

--- a/micro-location/micro-location/WemoScriptService.m
+++ b/micro-location/micro-location/WemoScriptService.m
@@ -28,7 +28,7 @@
     static WemoScriptService* _sharedClient = nil;
     static dispatch_once_t oncePredicate;
     dispatch_once(&oncePredicate, ^{
-        _sharedClient = [[self alloc] initWithBaseURL:[NSURL URLWithString:@"http://default-environment-tvmbb2aymn.elasticbeanstalk.com"]];
+        _sharedClient = [[self alloc] initWithBaseURL:[NSURL URLWithString:@"http://microlocation.elasticbeanstalk.com"]];
     });
     
     return _sharedClient;


### PR DESCRIPTION
Fixed posted uuid string, updated services with beanstalk url, updated geofencing tab with new sql return, added missing semicolon.

AppDelegate - edited uuid string to remove Apple characters
GetBeaconService - changed url to microlocation.elasticbeanstalk.com
SecondViewController - changed case sensitive string to reflect case in mysql
WemoScriptService - added missing semicolon in header file and changed url to microlocation.elasticbeanstalk.com in implementation file